### PR TITLE
Switch to linkpool blockchain provider over infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Latest library release is available on [Maven Central](https://search.maven.org/
 ```
 
 # Usage Examples
-We are using infura as our choice of blockchain provider and it requires a [project id](https://infura.io/docs/gettingStarted/authentication) to be bundled with the url.
-Feel free to try other blockchain providers
+We are using [linkpool](https://www.linkpool.io/) as our choice of blockchain provider.
+Feel free to try other blockchain providers (as [infra](https://infura.io/) or any others).
 ```
+resolution = new Resolution("https://main-rpc.linkpool.io");
+
 resolution = new Resolution("https://mainnet.infura.io/v3/<ProjectId>");
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ targetCompatibility = 1.8
 
 group = "com.unstoppabledomains.resolution"
 archivesBaseName = "resolution"
-version = "1.2.0"
+version = "1.2.1"
 
 repositories {
     // Use jcenter for resolving dependencies.

--- a/samples.md
+++ b/samples.md
@@ -1,7 +1,7 @@
 ### Reference example
 Android development is very strict on the blocking the main UI thread.
 And it order to make a call using our library you might want to wrap the call into AsyncTask or simillar classes which allows executing async operations on a separate threads
-This example is in Kotlin
+This example is in Kotlin:
 ```
 import android.os.AsyncTask
 import com.unstoppabledomains.exceptions.NamingServiceException
@@ -10,8 +10,7 @@ import com.unstoppabledomains.resolution.Resolution
 data class ResolutionResult(val error: NamingServiceException?, val address: String?) {}
 
 class AsyncResolution : AsyncTask<String, String, ResolutionResult>() {
-    private val tool: Resolution =
-        Resolution("https://mainnet.infura.io/v3/<ProjectId>")
+    private val tool: Resolution = Resolution("https://main-rpc.linkpool.io")
 
     override fun doInBackground(vararg params: String?): ResolutionResult {
         val domain =  params[0]
@@ -26,9 +25,7 @@ class AsyncResolution : AsyncTask<String, String, ResolutionResult>() {
     }
 }
 ```
-ProjectID is a given from [infura](https://infura.io/docs)
 After you can use it in the following manner: 
-
 ```
 val task = AsyncResolution().execute("brad.crypto", "ETH")
 val result: ResolutionResult = task.get()
@@ -68,8 +65,7 @@ import com.unstoppabledomains.resolution.Resolution
 data class ResolutionResult(val error: NamingServiceException?, val address: String?) {}
 
 class AsyncResolution : AsyncTask<String, String, ResolutionResult>() {
-    private val tool: Resolution =
-        Resolution("https://mainnet.infura.io/v3/0728d3860f484d6683ec3e3033f73b08")
+    private val tool: Resolution = Resolution("https://main-rpc.linkpool.io")
 
     override fun doInBackground(vararg params: String?): ResolutionResult {
         val domain =  params[0]

--- a/src/main/java/com/unstoppabledomains/resolution/contracts/HTTPUtil.java
+++ b/src/main/java/com/unstoppabledomains/resolution/contracts/HTTPUtil.java
@@ -36,7 +36,7 @@ public class HTTPUtil {
         URL posturl = new URL(url);
         HttpURLConnection con = (HttpURLConnection) posturl.openConnection();
         con.setRequestMethod("POST");
-        con.setRequestProperty("Content-Type", "application/json; utf-8");
+        con.setRequestProperty("Content-Type", "application/json");
         con.setRequestProperty("Accept", "application/json");
         con.addRequestProperty("User-Agent", "UnstoppableDomains/resolution-java");
         con.setDoOutput(true);

--- a/src/test/java/com/unstoppabledomains/ProxyReaderTest.java
+++ b/src/test/java/com/unstoppabledomains/ProxyReaderTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ProxyReaderTest {
 
-    private static final String URL = "https://mainnet.infura.io/v3/781c1e5cae32417b93eac26042950d25";
+    private static final String URL = "https://main-rpc.linkpool.io";
     private static final String ADDRESS = "0x7ea9Ee21077F84339eDa9C80048ec6db678642B1";
     private static final String TOKEN_ID_HASH = "0x756e4e998dbffd803c21d23b06cd855cdc7a4b57706c95964a37e24b47c10fc9";
     private static final BigInteger TOKEN_ID = new BigInteger(TOKEN_ID_HASH.replace("0x", ""), 16);

--- a/src/test/java/com/unstoppabledomains/resolution/LibraryTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/LibraryTest.java
@@ -18,7 +18,7 @@ public class LibraryTest {
 
     @BeforeEach
     public void initEach() {
-        resolution = new Resolution("https://mainnet.infura.io/v3/781c1e5cae32417b93eac26042950d25");
+        resolution = new Resolution("https://main-rpc.linkpool.io");
     }
 
     @Test


### PR DESCRIPTION
This PR:
- Replaces [infra.io](https://www.infra.io/) with [linkpool.io](https://www.linkpool.io/) as a preffered blockchain provider for tests & samples;
- Bump to v1.2.1.