### PR TITLE
support of the new keys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    testLogging {
+        showStandardStreams = true
+    }
 }
 
 publishing {

--- a/src/main/java/com/unstoppabledomains/resolution/contracts/BaseContract.java
+++ b/src/main/java/com/unstoppabledomains/resolution/contracts/BaseContract.java
@@ -10,12 +10,14 @@ import com.google.gson.JsonParser;
 import com.unstoppabledomains.exceptions.NSExceptionCode;
 import com.unstoppabledomains.exceptions.NSExceptionParams;
 import com.unstoppabledomains.exceptions.NamingServiceException;
+import com.unstoppabledomains.resolution.contracts.cns.ProxyData;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public abstract class BaseContract {
@@ -50,6 +52,23 @@ public abstract class BaseContract {
     } catch (ArrayIndexOutOfBoundsException e) {
       return null;
     }
+  }
+
+  protected ProxyData fetchData(Object[] args) throws NamingServiceException {
+    Tuple answ = fetchMethod("getData", args);
+    String resolver = "";
+    String owner = "";
+    BigInteger resolverValue = (BigInteger) answ.get(0);
+    BigInteger ownerValue = (BigInteger) answ.get(1);
+
+    if (resolverValue.intValue() != 0) {  
+      resolver = "0x" + ((BigInteger) answ.get(0)).toString(16);
+    }
+    if (ownerValue.intValue() != 0 ) {
+      owner = "0x" + ((BigInteger) answ.get(1)).toString(16);
+    }
+    String[] values = (String[]) answ.get(2);
+    return new ProxyData(resolver, owner, values);
   }
 
   private Tuple fetchMethod(String method, Object[] args) throws NamingServiceException {

--- a/src/main/java/com/unstoppabledomains/resolution/contracts/cns/ProxyData.java
+++ b/src/main/java/com/unstoppabledomains/resolution/contracts/cns/ProxyData.java
@@ -6,7 +6,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class ProxyData {
-  String resolver;
-  String owner;
-  String[] values;
+  private String resolver;
+  private String owner;
+  private String[] values;
 }

--- a/src/main/java/com/unstoppabledomains/resolution/contracts/cns/ProxyData.java
+++ b/src/main/java/com/unstoppabledomains/resolution/contracts/cns/ProxyData.java
@@ -1,0 +1,12 @@
+package com.unstoppabledomains.resolution.contracts.cns;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ProxyData {
+  String resolver;
+  String owner;
+  String[] values;
+}

--- a/src/main/java/com/unstoppabledomains/resolution/contracts/cns/ProxyReader.java
+++ b/src/main/java/com/unstoppabledomains/resolution/contracts/cns/ProxyReader.java
@@ -1,5 +1,6 @@
 package com.unstoppabledomains.resolution.contracts.cns;
 
+import com.unstoppabledomains.exceptions.NamingServiceException;
 import com.unstoppabledomains.resolution.contracts.BaseContract;
 
 import java.math.BigInteger;
@@ -29,6 +30,13 @@ public class ProxyReader extends BaseContract {
         args[1] = tokenID;
 
         return fetchOne("get", args);
+    }
+
+    public ProxyData getProxyData(String[] records, BigInteger tokenID) throws NamingServiceException {
+        Object[] args = new Object[2];
+        args[0] = records;
+        args[1] = tokenID;
+        return fetchData(args);
     }
 
     @Override

--- a/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
@@ -103,6 +103,9 @@ public class ResolutionTest {
 
         ipfs = resolution.getIpfsHash("johnnyjumper.zil");
         assertEquals("QmQ38zzQHVfqMoLWq2VeiMLHHYki9XktzXxLYTWXt8cydu", ipfs);
+
+        ipfs = resolution.getIpfsHash("reseller-test-udtesting-341567718146.crypto");
+        assertEquals("QmVJ26hBrwwNAPVmLavEFXDUunNDXeFSeMPmHuPxKe6dJv", ipfs);
     }
 
     @Test


### PR DESCRIPTION
This gives us the support of the new ipfs record key: dweb.ipfs.hash in a backward-compatible way. 

Introduce ProxyData Object. This is basically a response from the "getData" method of ProxyReader contract. 
it holds the resolver address and owner address as BigIntegers as well as an array of values for asked keys.

A plan in the next PR is to move towards using a single HTTP call to the proxy reader instead of several and remove the old code from the pre-ProxyReader epoch.
