### PR TITLE
upgraded infura keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.11.0
+* Use Infura Etherum Provider by default
+
 ## 1.10.0
 * Fixed missing information on NamingServiceException thrown from ZNS
 * Introduced IProvider interface -- implement it in order to get full control over HTTP requests to blockchain provider  

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ The most recent release of this library is available on [Maven Central](https://
 
 # Usage
 
-This library uses [linkpool](https://linkpool.io/) as default blockchain provider for CNS & ENS and 
-[zilliqa](https://zilliqa.com) for ZNS (**Mainnet** is default network for all).  
-If you want to use an alternative blockchain provider such as [infura](https://infura.io/) (or any other), you can
- change default settings:
+## Default Ethereum Providers
+resolution-java library provides zero-configuration experience by using built-in production-ready Infura endpoint by default.
+Default Ethereum provider is free to use without restrictions and rate-limits for CNS (.crypto domains) resolution.
+To resolve ENS domains on production it's recommended to change Ethereum provider.
+
+If you want to use an alternative blockchain provider such as [infura](https://infura.io/) (or any other), you can change default settings:
  
 ```java
 // Default config: 

--- a/src/main/java/com/unstoppabledomains/resolution/Resolution.java
+++ b/src/main/java/com/unstoppabledomains/resolution/Resolution.java
@@ -21,7 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 public class Resolution implements DomainResolution {
-    private static final String LINKPOOL_DEFAULT_URL = "https://main-rpc.linkpool.io";
+    private static final String CNS_DEFAULT_URL = "https://mainnet.infura.io/v3/c4bb906ed6904c42b19c95825fe55f39";
+    private static final String ENS_DEFAULT_URL = "https://mainnet.infura.io/v3/e05c36b6b2134ccc9f2594ddff94c136";
     private static final String ZILLIQA_DEFAULT_URL = "https://api.zilliqa.com";
 
     private Map<NamingServiceType, NamingService> services;
@@ -39,12 +40,12 @@ public class Resolution implements DomainResolution {
 
     /**
      * Create resolution object with default config:
-     * <a href="https://linkpool.io">linkpool</a> blockchain provider for ENS and CNS and
+     * <a href="https://infura.io">infura</a> blockchain provider for ENS and CNS and
      * <a href="https://zilliqa.com">zilliqa</a> for ZNS
      */
     public Resolution() {
         IProvider provider = new DefaultProvider();
-        services = getServices(LINKPOOL_DEFAULT_URL, provider);
+        services = getServices(CNS_DEFAULT_URL, ENS_DEFAULT_URL, provider);
     }
 
     /**
@@ -57,7 +58,7 @@ public class Resolution implements DomainResolution {
     @Deprecated
     public Resolution(String blockchainProviderUrl) {
         IProvider provider = new DefaultProvider();
-        services = getServices(blockchainProviderUrl, provider);
+        services = getServices(blockchainProviderUrl, blockchainProviderUrl, provider);
     }
 
     private Resolution(Map<NamingServiceType, NamingService> services) {
@@ -152,10 +153,10 @@ public class Resolution implements DomainResolution {
         return getOwner(domain);
     }
 
-    private Map<NamingServiceType, NamingService> getServices(String blockchainProviderUrl, IProvider provider) {
+    private Map<NamingServiceType, NamingService> getServices(String CnsProviderUrl, String EnsProviderUrl, IProvider provider) {
         return new HashMap<NamingServiceType, NamingService>() {{
-            put(NamingServiceType.CNS, new CNS(new NSConfig(Network.MAINNET, blockchainProviderUrl), provider));
-            put(NamingServiceType.ENS, new ENS(new NSConfig(Network.MAINNET, blockchainProviderUrl), provider));
+            put(NamingServiceType.CNS, new CNS(new NSConfig(Network.MAINNET, CnsProviderUrl), provider));
+            put(NamingServiceType.ENS, new ENS(new NSConfig(Network.MAINNET, EnsProviderUrl), provider));
             put(NamingServiceType.ZNS, new ZNS(new NSConfig(Network.MAINNET, ZILLIQA_DEFAULT_URL), provider));
         }};
     }
@@ -175,8 +176,8 @@ public class Resolution implements DomainResolution {
 
         private Builder() {
             serviceConfigs = new HashMap<NamingServiceType, NSConfig>() {{
-                put(NamingServiceType.CNS, new NSConfig(Network.MAINNET, LINKPOOL_DEFAULT_URL));
-                put(NamingServiceType.ENS, new NSConfig(Network.MAINNET, LINKPOOL_DEFAULT_URL));
+                put(NamingServiceType.CNS, new NSConfig(Network.MAINNET, CNS_DEFAULT_URL));
+                put(NamingServiceType.ENS, new NSConfig(Network.MAINNET, ENS_DEFAULT_URL));
                 put(NamingServiceType.ZNS, new NSConfig(Network.MAINNET, ZILLIQA_DEFAULT_URL));
             }};
             provider = new DefaultProvider();

--- a/src/main/java/com/unstoppabledomains/resolution/Resolution.java
+++ b/src/main/java/com/unstoppabledomains/resolution/Resolution.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 public class Resolution implements DomainResolution {
     private static final String CNS_DEFAULT_URL = "https://mainnet.infura.io/v3/c4bb906ed6904c42b19c95825fe55f39";
-    private static final String ENS_DEFAULT_URL = "https://mainnet.infura.io/v3/e05c36b6b2134ccc9f2594ddff94c136";
+    private static final String ENS_DEFAULT_URL = "https://mainnet.infura.io/v3/d423cf2499584d7fbe171e33b42cfbee";
     private static final String ZILLIQA_DEFAULT_URL = "https://api.zilliqa.com";
 
     private Map<NamingServiceType, NamingService> services;

--- a/src/main/java/com/unstoppabledomains/resolution/Resolution.java
+++ b/src/main/java/com/unstoppabledomains/resolution/Resolution.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 public class Resolution implements DomainResolution {
-    private static final String CNS_DEFAULT_URL = "https://mainnet.infura.io/v3/c4bb906ed6904c42b19c95825fe55f39";
+    private static final String CNS_DEFAULT_URL = "https://mainnet.infura.io/v3/e0c0cb9d12c440a29379df066de587e6";
     private static final String ENS_DEFAULT_URL = "https://mainnet.infura.io/v3/d423cf2499584d7fbe171e33b42cfbee";
     private static final String ZILLIQA_DEFAULT_URL = "https://api.zilliqa.com";
 

--- a/src/main/resources/com/unstoppabledomains/config/network/network-config.json
+++ b/src/main/resources/com/unstoppabledomains/config/network/network-config.json
@@ -43,6 +43,10 @@
                 "TwitterValidationOperator": {
                     "address": "0xbb486C6E9cF1faA86a6E3eAAFE2e5665C0507855",
                     "legacyAddresses": []
+                },
+                "FreeMinter": {
+                    "address": "0x1fC985cAc641ED5846b631f96F35d9b48Bc3b834",
+                    "legacyAddresses": []
                 }
             }
         },
@@ -82,6 +86,10 @@
                 },
                 "TwitterValidationOperator": {
                     "address": "0x1CB337b3b208dc29a6AcE8d11Bb591b66c5Dd83d",
+                    "legacyAddresses": []
+                },
+                "FreeMinter": {
+                    "address": "0x84214215904cDEbA9044ECf95F3eBF009185AAf4",
                     "legacyAddresses": []
                 }
             }

--- a/src/test/java/com/unstoppabledomains/ProxyReaderTest.java
+++ b/src/test/java/com/unstoppabledomains/ProxyReaderTest.java
@@ -18,8 +18,7 @@ public class ProxyReaderTest {
 
     @BeforeAll
     public static void init() {
-        final String testingProviderUrl = System.getenv("TESTING_PROVIDER_URL");
-        proxyReaderContract = new ProxyReader(testingProviderUrl, ADDRESS, new DefaultProvider());
+        proxyReaderContract = new ProxyReader(TestUtils.TESTING_CNS_PROVIDER_URL, ADDRESS, new DefaultProvider());
     }
 
     @Test

--- a/src/test/java/com/unstoppabledomains/ProxyReaderTest.java
+++ b/src/test/java/com/unstoppabledomains/ProxyReaderTest.java
@@ -10,7 +10,7 @@ import java.math.BigInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ProxyReaderTest {
-    private static final String ADDRESS = "0x7ea9Ee21077F84339eDa9C80048ec6db678642B1";
+    private static final String ADDRESS = "0xa6E7cEf2EDDEA66352Fd68E5915b60BDbb7309f5";
     private static final String TOKEN_ID_HASH = "0x756e4e998dbffd803c21d23b06cd855cdc7a4b57706c95964a37e24b47c10fc9";
     private static final BigInteger TOKEN_ID = new BigInteger(TOKEN_ID_HASH.replace("0x", ""), 16);
 

--- a/src/test/java/com/unstoppabledomains/TestUtils.java
+++ b/src/test/java/com/unstoppabledomains/TestUtils.java
@@ -9,6 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestUtils {
+
+    public static final String TESTING_CNS_PROVIDER_URL = "https://mainnet.infura.io/v3/e0c0cb9d12c440a29379df066de587e6";
+    public static final String TESTING_ENS_PROVIDER_URL = "https://mainnet.infura.io/v3/d423cf2499584d7fbe171e33b42cfbee";
+    public static final String TESTING_INFURA_CNS_PROJECT_ID = "e0c0cb9d12c440a29379df066de587e6";
+    public static final String TESTING_INFURA_ENS_PROJECT_ID = "d423cf2499584d7fbe171e33b42cfbee";
+
     public static void expectError(Callable<String> f, NSExceptionCode code) throws Exception {
         try {
             f.call();

--- a/src/test/java/com/unstoppabledomains/resolution/ENSTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/ENSTest.java
@@ -14,7 +14,7 @@ public class ENSTest {
   
   @BeforeAll
   public static void init() {
-    final String testingProviderUrl = System.getenv("TESTING_PROVIDER_URL");
+    final String testingProviderUrl = System.getenv("TESTING_ENS_PROVIDER_URL");
     resolution = Resolution.builder()
             .providerUrl(NamingServiceType.CNS, testingProviderUrl)
             .providerUrl(NamingServiceType.ENS, testingProviderUrl)

--- a/src/test/java/com/unstoppabledomains/resolution/ENSTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/ENSTest.java
@@ -3,7 +3,6 @@ package com.unstoppabledomains.resolution;
 import com.unstoppabledomains.TestUtils;
 import com.unstoppabledomains.exceptions.ns.NSExceptionCode;
 import com.unstoppabledomains.exceptions.ns.NamingServiceException;
-import com.unstoppabledomains.resolution.naming.service.NamingServiceType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -14,11 +13,7 @@ public class ENSTest {
   
   @BeforeAll
   public static void init() {
-    final String testingProviderUrl = System.getenv("TESTING_ENS_PROVIDER_URL");
-    resolution = Resolution.builder()
-            .providerUrl(NamingServiceType.CNS, testingProviderUrl)
-            .providerUrl(NamingServiceType.ENS, testingProviderUrl)
-            .build();
+    resolution = new Resolution();
   }
 
   @Test

--- a/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
@@ -29,7 +29,10 @@ import java.util.Map;
 public class ResolutionTest {
 
     private static final String TESTING_PROVIDER_URL = System.getenv("TESTING_PROVIDER_URL");
+    private static final String TESTING_ENS_PROVIDER_URL = System.getenv("TESTING_ENS_PROVIDER_URL");
     private static final String TESTING_INFURA_PROJECT_ID = System.getenv("TESTING_INFURA_PROJECT_ID");
+    private static final String TESTING_INFURA_ENS_PROJECT_ID = System.getenv("TESTING_INFURA_ENS_PROJECT_ID");
+
 
     private static DomainResolution resolution;
 
@@ -37,7 +40,7 @@ public class ResolutionTest {
     public static void init() {
         resolution = Resolution.builder()
                 .providerUrl(NamingServiceType.CNS, TESTING_PROVIDER_URL)
-                .providerUrl(NamingServiceType.ENS, TESTING_PROVIDER_URL)
+                .providerUrl(NamingServiceType.ENS, TESTING_ENS_PROVIDER_URL)
                 .build();
     }
 
@@ -45,7 +48,7 @@ public class ResolutionTest {
     public void shouldResolveFromResolutionCreatedByBuilder() throws Exception {
         DomainResolution resolutionFromBuilder = Resolution.builder()
                 .chainId(NamingServiceType.ENS, Network.ROPSTEN)
-                .providerUrl(NamingServiceType.ENS, TESTING_PROVIDER_URL)
+                .providerUrl(NamingServiceType.ENS, TESTING_ENS_PROVIDER_URL)
                 .providerUrl(NamingServiceType.CNS, TESTING_PROVIDER_URL)
                 .build();
 
@@ -58,7 +61,7 @@ public class ResolutionTest {
     public void shouldResolveFromResolutionCreatedByBuilderWithInfura() throws Exception {
         DomainResolution resolutionFromBuilderWithInfura = Resolution.builder()
                 .chainId(NamingServiceType.ENS, Network.ROPSTEN)
-                .infura(NamingServiceType.ENS, TESTING_INFURA_PROJECT_ID)
+                .infura(NamingServiceType.ENS, TESTING_INFURA_ENS_PROJECT_ID)
                 .infura(NamingServiceType.CNS, Network.MAINNET, TESTING_INFURA_PROJECT_ID)
                 .build();
 

--- a/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
@@ -28,28 +28,19 @@ import java.util.Map;
 
 public class ResolutionTest {
 
-    private static final String TESTING_PROVIDER_URL = System.getenv("TESTING_PROVIDER_URL");
-    private static final String TESTING_ENS_PROVIDER_URL = System.getenv("TESTING_ENS_PROVIDER_URL");
-    private static final String TESTING_INFURA_PROJECT_ID = System.getenv("TESTING_INFURA_PROJECT_ID");
-    private static final String TESTING_INFURA_ENS_PROJECT_ID = System.getenv("TESTING_INFURA_ENS_PROJECT_ID");
-
-
     private static DomainResolution resolution;
 
     @BeforeAll
     public static void init() {
-        resolution = Resolution.builder()
-                .providerUrl(NamingServiceType.CNS, TESTING_PROVIDER_URL)
-                .providerUrl(NamingServiceType.ENS, TESTING_ENS_PROVIDER_URL)
-                .build();
+        resolution = new Resolution();
     }
 
     @Test
     public void shouldResolveFromResolutionCreatedByBuilder() throws Exception {
         DomainResolution resolutionFromBuilder = Resolution.builder()
                 .chainId(NamingServiceType.ENS, Network.ROPSTEN)
-                .providerUrl(NamingServiceType.ENS, TESTING_ENS_PROVIDER_URL)
-                .providerUrl(NamingServiceType.CNS, TESTING_PROVIDER_URL)
+                .providerUrl(NamingServiceType.ENS, TestUtils.TESTING_ENS_PROVIDER_URL)
+                .providerUrl(NamingServiceType.CNS, TestUtils.TESTING_CNS_PROVIDER_URL)
                 .build();
 
         assertEquals("0x8aad44321a86b170879d7a244c1e8d360c99dda8", resolutionFromBuilder.getOwner("brad.crypto"));
@@ -61,8 +52,8 @@ public class ResolutionTest {
     public void shouldResolveFromResolutionCreatedByBuilderWithInfura() throws Exception {
         DomainResolution resolutionFromBuilderWithInfura = Resolution.builder()
                 .chainId(NamingServiceType.ENS, Network.ROPSTEN)
-                .infura(NamingServiceType.ENS, TESTING_INFURA_ENS_PROJECT_ID)
-                .infura(NamingServiceType.CNS, Network.MAINNET, TESTING_INFURA_PROJECT_ID)
+                .infura(NamingServiceType.ENS, TestUtils.TESTING_INFURA_ENS_PROJECT_ID)
+                .infura(NamingServiceType.CNS, Network.MAINNET, TestUtils.TESTING_INFURA_CNS_PROJECT_ID)
                 .build();
 
         assertEquals("0x8aad44321a86b170879d7a244c1e8d360c99dda8", resolutionFromBuilderWithInfura.getOwner("brad.crypto"));


### PR DESCRIPTION
CNS_DEFAULT_URL -> using secured CNS key from UD. The key is whitelisted to use with only our contracts.
ENS_DEFAULT_URL -> using an unsecured public key for ENS only. This key will be removed once whitelisting issue resolves