### PR TITLE
Johnny/batch owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 * Introduced `Resolution#getBatchOwners` method to resolve owner addresses of many domains. 
   ** All domains provided should be from the same naming service (UNS or ZNS or ENS)
-  ** ZNS and ENS domains have a hard limit of 200 domains per call. 
+  ** ZNS and ENS domains have a hard limit of 255 domains per call. 
 ## 3.0.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+* Introduced `Resolution#getBatchOwners` method to resolve owner addresses of many domains. 
+  ** All domains provided should be from the same naming service (UNS or ZNS or ENS)
+  ** ZNS and ENS domains have a hard limit of 200 domains per call. 
 ## 3.0.0
 
 ### Breaking changes

--- a/src/main/java/com/unstoppabledomains/exceptions/ns/NSExceptionCode.java
+++ b/src/main/java/com/unstoppabledomains/exceptions/ns/NSExceptionCode.java
@@ -11,5 +11,7 @@ public enum NSExceptionCode {
   IncorrectMethodName,
   UnspecifiedResolver,
   UnsupportedCurrency,
-  NotImplemented;
+  NotImplemented,
+  InconsistentDomainArray,
+  MaxThreadLimit;
 }

--- a/src/main/java/com/unstoppabledomains/exceptions/ns/NSExceptionParams.java
+++ b/src/main/java/com/unstoppabledomains/exceptions/ns/NSExceptionParams.java
@@ -3,12 +3,15 @@ package com.unstoppabledomains.exceptions.ns;
 import java.util.regex.Pattern;
 
 public class NSExceptionParams {
+  public static final NSExceptionParams EMPTY_PARAMS = new NSExceptionParams(" ", " ");
+
   public String domain;
   public String namingService;
   public String coinTicker;
   public String contractAddress;
   public String methodName;
   public String record;
+  public String threadLimit;
 
   public NSExceptionParams(String format, String ...args) {
     Pattern pattern = Pattern.compile("\\|");
@@ -43,6 +46,10 @@ public class NSExceptionParams {
       }
       case "r": {
         record = value;
+        break ;
+      }
+      case "l": {
+        threadLimit = value;
         break ;
       }
       default: {

--- a/src/main/java/com/unstoppabledomains/exceptions/ns/NamingServiceException.java
+++ b/src/main/java/com/unstoppabledomains/exceptions/ns/NamingServiceException.java
@@ -5,7 +5,7 @@ public class NamingServiceException extends Exception {
   private final NSExceptionCode code;
   
   public NamingServiceException(NSExceptionCode code) {
-    super(messageFromCode(code, new NSExceptionParams("", "")));
+    super(messageFromCode(code, NSExceptionParams.EMPTY_PARAMS));
     this.code = code;
   }
 
@@ -47,6 +47,12 @@ public class NamingServiceException extends Exception {
       }
       case NotImplemented: {
         return "Method " + params.methodName + "is not implemented for this naming service: " + params.namingService;
+      }
+      case InconsistentDomainArray: {
+        return "Domains needs to be from the same naming service";
+      }
+      case MaxThreadLimit: {
+        return "Method " + params.methodName + " attempted to create more threads than " + params.threadLimit;
       }
       case UnknownError:
       default: 

--- a/src/main/java/com/unstoppabledomains/resolution/DomainResolution.java
+++ b/src/main/java/com/unstoppabledomains/resolution/DomainResolution.java
@@ -98,6 +98,15 @@ public interface DomainResolution {
     String getOwner(String domain) throws NamingServiceException;
     
     /**
+     * Resolves owner addresses for many domains
+     * @param domains string array of domain names you want to resolve
+     * @return String[] of owner addreses.
+     * @throws NamingServiceException
+     */
+    String[] getBatchOwners(String[] domains) throws NamingServiceException;
+
+
+    /**
      * Resolves dns records from a domain
      * 
      * @param domain domain name such as "brad.crypto"

--- a/src/main/java/com/unstoppabledomains/resolution/Resolution.java
+++ b/src/main/java/com/unstoppabledomains/resolution/Resolution.java
@@ -136,6 +136,16 @@ public class Resolution implements DomainResolution {
     }
 
     @Override
+    public String[] getBatchOwners(String[] domains) throws NamingServiceException {
+        for (int i = 0; i + 2 < domains.length; i++) {
+            if (findService(domains[i+1]) != findService(domains[i])) {
+                throw new NamingServiceException(NSExceptionCode.InconsistentDomainArray);
+            }
+        }
+        return findService(domains[0]).batchOwners(domains);
+    }
+
+    @Override
     public List<DnsRecord> getDns(String domain, List<DnsRecordsType> types) throws NamingServiceException, DnsException {
         NamingService service = findService(domain);
         return service.getDns(domain, types);

--- a/src/main/java/com/unstoppabledomains/resolution/contracts/uns/ProxyReader.java
+++ b/src/main/java/com/unstoppabledomains/resolution/contracts/uns/ProxyReader.java
@@ -3,6 +3,8 @@ package com.unstoppabledomains.resolution.contracts.uns;
 import com.unstoppabledomains.exceptions.ns.NamingServiceException;
 import com.unstoppabledomains.resolution.contracts.BaseContract;
 import com.unstoppabledomains.resolution.contracts.interfaces.IProvider;
+import com.unstoppabledomains.util.Utilities;
+import com.unstoppabledomains.resolution.artifacts.Numeric;
 
 import java.math.BigInteger;
 
@@ -22,6 +24,17 @@ public class ProxyReader extends BaseContract {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public String[] batchOwners(BigInteger[] tokenIDs) throws Exception {
+            Object[] args = { tokenIDs };
+            BigInteger[] owners = fetchOne("ownerOfForMany", args);
+            String[] convertedOwners = new String[owners.length];
+            for (int i =0; i < owners.length; i++) {
+                String hexRepresentation = owners[i].toString(16);
+                convertedOwners[i] = "0x" + hexRepresentation;
+            }
+            return convertedOwners;
     }
 
     public String getRecord(String recordKey, BigInteger tokenID) throws Exception {

--- a/src/main/java/com/unstoppabledomains/resolution/naming/service/ENS.java
+++ b/src/main/java/com/unstoppabledomains/resolution/naming/service/ENS.java
@@ -19,8 +19,6 @@ import com.unstoppabledomains.util.Utilities;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.swing.event.SwingPropertyChangeSupport;
-
 public class ENS extends BaseNamingService {
 
   private final Registry registryContract;

--- a/src/main/java/com/unstoppabledomains/resolution/naming/service/NamingService.java
+++ b/src/main/java/com/unstoppabledomains/resolution/naming/service/NamingService.java
@@ -17,6 +17,7 @@ public interface NamingService {
     String getRecord(String domain, String recordKey) throws NamingServiceException;
 
     String getOwner(String domain) throws NamingServiceException;
+    String[] batchOwners(String[] domain) throws NamingServiceException;
 
     String getNamehash(String domain) throws NamingServiceException;
 

--- a/src/main/java/com/unstoppabledomains/resolution/naming/service/UNS.java
+++ b/src/main/java/com/unstoppabledomains/resolution/naming/service/UNS.java
@@ -96,7 +96,7 @@ public class UNS extends BaseNamingService {
       return owners;
     } catch(Exception e) {
       throw configureNamingServiceException(e,
-        new NSExceptionParams("n", "UNS"));
+        new NSExceptionParams("d|n", String.join(", ", domains),"UNS"));
     }
   }
 

--- a/src/main/java/com/unstoppabledomains/resolution/naming/service/UNS.java
+++ b/src/main/java/com/unstoppabledomains/resolution/naming/service/UNS.java
@@ -20,9 +20,11 @@ import com.unstoppabledomains.util.Utilities;
 import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class UNS extends BaseNamingService {
   private final ProxyReader proxyReaderContract;
@@ -66,6 +68,7 @@ public class UNS extends BaseNamingService {
     return result;
   }
 
+  @Override
   public  String getOwner(String domain) throws NamingServiceException {
     try {
       BigInteger tokenID = getTokenID(domain);
@@ -78,6 +81,25 @@ public class UNS extends BaseNamingService {
     } catch (Exception e) {
       throw configureNamingServiceException(e,
           new NSExceptionParams("d|n", domain, "UNS"));
+    }
+  }
+
+  @Override
+  public String[] batchOwners(String[] domains) throws NamingServiceException {
+    try {
+      BigInteger[] tokenIDs = new BigInteger[domains.length];
+      for (int i = 0; i < domains.length; i++) {
+        tokenIDs[i] = getTokenID(domains[i]);
+      }
+      String[] rawOwners = proxyReaderContract.batchOwners(tokenIDs);
+      String[] owners = new String[rawOwners.length];
+      for (int i = 0; i < rawOwners.length; i++) {
+        owners[i] = Utilities.isEmptyResponse(rawOwners[i]) ? null : rawOwners[i];
+      }
+      return owners;
+    } catch(Exception e) {
+      throw configureNamingServiceException(e,
+        new NSExceptionParams("n", "UNS"));
     }
   }
 

--- a/src/main/java/com/unstoppabledomains/resolution/naming/service/UNS.java
+++ b/src/main/java/com/unstoppabledomains/resolution/naming/service/UNS.java
@@ -1,7 +1,6 @@
 
 package com.unstoppabledomains.resolution.naming.service;
 
-import com.unstoppabledomains.config.network.NetworkConfigLoader;
 import com.unstoppabledomains.exceptions.ContractCallException;
 import com.unstoppabledomains.exceptions.dns.DnsException;
 import com.unstoppabledomains.exceptions.ns.NSExceptionCode;
@@ -20,11 +19,9 @@ import com.unstoppabledomains.util.Utilities;
 import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class UNS extends BaseNamingService {
   private final ProxyReader proxyReaderContract;
@@ -109,7 +106,7 @@ public class UNS extends BaseNamingService {
     List<String> keys = constructDnsRecords(types);
     ProxyData data = resolveKeys(keys.toArray(new String[keys.size()]), domain);
     List<String> values = data.getValues();
-    Map<String, String> rawData = new HashMap();
+    Map<String, String> rawData = new HashMap<>();
     for (int i = 0; i < values.size(); i++) {
       rawData.put(keys.get(i), values.get(i));
     }
@@ -173,7 +170,7 @@ public class UNS extends BaseNamingService {
   }
 
   private List<String> constructDnsRecords(List<DnsRecordsType> types) {
-    List<String> records = new ArrayList();
+    List<String> records = new ArrayList<>();
     records.add("dns.ttl");
     for (DnsRecordsType type: types) {
       records.add("dns." + type.toString());
@@ -213,7 +210,7 @@ public class UNS extends BaseNamingService {
   }
 
 
-  private String owner(BigInteger tokenID) throws NamingServiceException {
+  private String owner(BigInteger tokenID) {
     return proxyReaderContract.getOwner(tokenID);
   }
 

--- a/src/main/java/com/unstoppabledomains/resolution/naming/service/ZNS.java
+++ b/src/main/java/com/unstoppabledomains/resolution/naming/service/ZNS.java
@@ -69,6 +69,35 @@ public class ZNS extends BaseNamingService {
     }
 
     @Override
+    public String[] batchOwners(String[] domains) throws NamingServiceException {
+        if (domains.length > 255) {
+            throw new NamingServiceException(NSExceptionCode.MaxThreadLimit, new NSExceptionParams("m|l", "Zns#batchOwners", "200"));
+          }
+          String[] owners = new String[domains.length];
+          Thread[] threads = new Thread[domains.length];
+          for (int i = 0; i < domains.length; i++) {
+            final int index = i;
+            threads[i] = new Thread(() -> {
+              try {
+                String owner = getOwner(domains[index]);
+                owners[index] = Utilities.isEmptyResponse(owner) ? null : owner;
+              } catch(Exception e) {
+                owners[index] = null;
+              }
+            });
+            threads[i].start();
+          }
+          for (Thread thread: threads) {
+            try {
+              thread.join();
+            } catch (InterruptedException e) {
+              throw new NamingServiceException(NSExceptionCode.UnknownError, NSExceptionParams.EMPTY_PARAMS, e);
+            }
+          }
+          return owners;
+    }
+
+    @Override
     public String getRecord(String domain, String key) throws NamingServiceException {
         try {
             JsonObject records = getAllRecords(domain);

--- a/src/test/java/com/unstoppabledomains/TestUtils.java
+++ b/src/test/java/com/unstoppabledomains/TestUtils.java
@@ -16,7 +16,7 @@ public class TestUtils {
     public static final String TESTING_ENS_PROVIDER_URL = "https://mainnet.infura.io/v3/d423cf2499584d7fbe171e33b42cfbee";
     public static final String TESTING_ZNS_PROVIDER_URL = "https://dev-api.zilliqa.com";
 
-    public static void expectError(Callable<String> f, NSExceptionCode code) throws Exception {
+    public static <T> void expectError(Callable<T> f, NSExceptionCode code) throws Exception {
         try {
             f.call();
             System.out.println("Didn't throw an " + code + " exception");
@@ -29,7 +29,7 @@ public class TestUtils {
         }
     }
 
-    public static void expectError(Callable<String> f, NSExceptionCode code, Throwable cause) throws Exception {
+    public static <T> void expectError(Callable<T> f, NSExceptionCode code, Throwable cause) throws Exception {
         try {
             f.call();
             System.out.println("Didn't throw an " + code + " exception");

--- a/src/test/java/com/unstoppabledomains/resolution/ENSTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/ENSTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.Arrays;
 
 public class ENSTest {
   private static DomainResolution resolution;
@@ -40,5 +43,20 @@ public class ENSTest {
 
     addr = resolution.getAddress("monkybrain.eth", "EtH");
     assertEquals("0x842f373409191cff2988a6f19ab9f605308ee462", addr);
+  }
+
+  @Test
+  public void batchOwnersTest() throws NamingServiceException {
+    String[] domains = { "brad.eth", "monkybrain.eth", "udtestdevnotexist.kred", "matthewgould.eth", "testthing.eth" };
+    String[] owners = resolution.getBatchOwners(domains);
+    String[] correctOwnerAddresses = { "0x1af001667bb945d1bdbb05145eea7c21d86737f7",  "0x842f373409191cff2988a6f19ab9f605308ee462", null, "0x714ef33943d925731fbb89c99af5780d888bd106", "0x904dac3347ea47d208f3fd67402d039a3b99859"};
+    assertArrayEquals(owners, correctOwnerAddresses);
+  }
+
+  @Test
+  public void batchOwnerOverflowTest() throws Exception {
+    String[] domains = new String[300];
+    Arrays.fill(domains, "somedomain.eth");
+    TestUtils.expectError(() -> resolution.getBatchOwners(domains), NSExceptionCode.MaxThreadLimit);
   }
 }

--- a/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
@@ -281,6 +281,12 @@ public class ResolutionTest {
     }
 
     @Test
+    public void getBatchOwnersInconsistentArray() throws Exception {
+        String[] domains = { "brad.crypto", "domain.eth", "something.zil" };
+        TestUtils.expectError(() -> resolution.getBatchOwners(domains), NSExceptionCode.InconsistentDomainArray);
+    }
+
+    @Test
     public void getOwnerFailTest() throws Exception {
         TestUtils.expectError(() -> resolution.getOwner("unregistered.crypto"), NSExceptionCode.UnregisteredDomain);
         TestUtils.expectError(() -> resolution.getOwner("unregistered.wallet"), NSExceptionCode.UnregisteredDomain);

--- a/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
+++ b/src/test/java/com/unstoppabledomains/resolution/ResolutionTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -254,6 +255,29 @@ public class ResolutionTest {
 
         owner = resolution.getOwner("testing.zil");
         assertEquals("0x003e3cdfeceae96efe007f8196a1b1b1df547eee", owner);
+    }
+
+    @Test
+    public void getBatchOwnersTest() throws NamingServiceException {
+        String[] domains = { "testing.crypto", "unregistered.crypto", "udtestdev-my-new-tls.wallet", "brad.crypto"};
+        String[] owners = resolution.getBatchOwners(domains);
+        String[] correctOwnerAddresses = { "0x58ca45e932a88b2e7d0130712b3aa9fb7c5781e2", null, "0x6ec0deed30605bcd19342f3c30201db263291589", "0x499dd6d875787869670900a2130223d85d4f6aa7"};
+        assertArrayEquals(owners, correctOwnerAddresses);
+    }
+    
+    @Test
+    public void getBatchOwnersZnsOverflow() throws Exception {
+        String[] domains = new String[300];
+        Arrays.fill(domains, "somedomain.zil");
+        TestUtils.expectError(() -> resolution.getBatchOwners(domains), NSExceptionCode.MaxThreadLimit);
+    }
+
+    @Test
+    public void getBatchOwnersZnsTest() throws Exception {
+        String[] domains = { "zero.zil", "fff.zil" };
+        String[] owners = resolution.getBatchOwners(domains);
+        String[] correctOwnerAddresses = { "0x5e398755d4e010e144e454fb5554bd68b28a8d9f", null};
+        assertArrayEquals(owners, correctOwnerAddresses);
     }
 
     @Test


### PR DESCRIPTION
Introduced Resolution#getBatchOwners method. Resolves owner addresses of many domains.

For ENS and ZNS cases I had to create a separate thread for each domain to speed up the resolution process.
Because of this, I ended up with the hard-coded limit of 255 domains for those Naming Services. 

In case if we get a request to remove this limit we can re-group it a little and distribute an equal amount of domain per thread. 

Pivotal story: https://www.pivotaltracker.com/story/show/179254063
