### PR TITLE
[DT-740] feat: Add .zil resolution from UNS

### DIFF
--- a/src/main/java/com/unstoppabledomains/resolution/DomainResolution.java
+++ b/src/main/java/com/unstoppabledomains/resolution/DomainResolution.java
@@ -80,15 +80,16 @@ public interface DomainResolution {
     String getMultiChainAddress(String domain, String ticker, String chain) throws NamingServiceException;
 
     /**
-     * Produces a getNamehash for a specific domain
+     * Produces a getNamehash for a specific domain and naming service
      *
      * @param domain domain name such as "brad.crypto"
+     * @param serviceType which service to use for namehashing
      * @return getNamehash of a domain for a specific NamingService
      * @throws NamingServiceException if tld of the domain is not recognized
      * @see <a href="https://docs.ens.domains/contract-api-reference/name-processing">
      * https://docs.ens.domains/contract-api-reference/name-processing </a>
      */
-    String getNamehash(String domain) throws NamingServiceException;
+    String getNamehash(String domain, NamingServiceType serviceType) throws NamingServiceException;
 
     /**
      * Resolves domain for an ipfs hash

--- a/src/main/java/com/unstoppabledomains/resolution/naming/service/uns/L2Resolver.java
+++ b/src/main/java/com/unstoppabledomains/resolution/naming/service/uns/L2Resolver.java
@@ -33,8 +33,14 @@ public class L2Resolver {
     try {
       return processFutureResult(l2result);
     } catch (NamingServiceException e) {
-      if (e.getCode() != NSExceptionCode.UnregisteredDomain && e.getCode() != NSExceptionCode.ReverseResolutionNotSpecified) {
-        throw e;
+      switch (e.getCode()) {
+        case UnregisteredDomain:
+        case ReverseResolutionNotSpecified:
+        case UnsupportedDomain:
+        case NotImplemented:
+          break;
+        default:
+          throw e;
       }
     }
     return processFutureResult(l1result);

--- a/src/main/java/com/unstoppabledomains/resolution/naming/service/uns/UNSInternal.java
+++ b/src/main/java/com/unstoppabledomains/resolution/naming/service/uns/UNSInternal.java
@@ -51,9 +51,6 @@ class UNSInternal extends BaseNamingService {
 
   public Boolean isSupported(String domain) throws NamingServiceException {
     String[] split = domain.split("\\.");
-    if (split.length == 0 || split[split.length - 1].equals("zil")) {
-      return false;
-    }
     BigInteger tokenID;
     try {
       tokenID = getTokenID(split[split.length - 1]);


### PR DESCRIPTION
## Changes
- Updated `Resolution` logic to resolve `.zil` domains on ZNS and UNS using the `L2Resolver`
-- Added `NamingServiceType` to `namehash` function to get namehashes for ZNS and UNS specifically
-- Added implementation of `locations` and `batchOwners` to ZNS naming service
- Added/updated tests

Notes:
- The final implementation is different from the original description in 
https://linear.app/unstoppable-domains/issue/DT-740/update-resolution-libraries-to-support-zil-resolution-on-polygon
to be in line with implementation in resolution-js (https://github.com/unstoppabledomains/resolution/pull/207)
- Blocked by #75 to avoid conflicts